### PR TITLE
fix reversely PC wrap problems

### DIFF
--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -270,6 +270,12 @@ int hardware::run_request(server_action &sa) {
 				debug_printf("PC wrapped\n");
 				pc_offset += MARGA_MEM_SIZE;
 			}
+			if (pc_hw > old_pc_hw + MARGA_MEM_SIZE -16) {
+				// PC has jumped backward due to a wrap from waiting/pausing 
+				debug_printf("PC Inversely wrapped: Loop %u | Mem: 0x%zx | RxReads: %u | Exec: %u | PC_HW: 0x%zx | OLD_PC_HW: 0x%zx\n",
+                   execution_loops, mem_offset, rx_reads_per_loop, exec, pc_hw, old_pc_hw);
+				pc_offset -= MARGA_MEM_SIZE;
+			}
 			old_pc_hw = pc_hw;
 
 			size_t pc = pc_hw + pc_offset;

--- a/src/iface.cpp
+++ b/src/iface.cpp
@@ -215,7 +215,7 @@ void iface::init(unsigned port) {
 }
 
 void iface::run_stream() {
-	const unsigned max_size = 1024*1024*32;
+	const unsigned max_size = 1024*1024*320;
 	const unsigned max_nodes = 8192;
 
 	char *reply_buf = (char *)malloc(max_size);


### PR DESCRIPTION

### Problem

When the PC is paused (e.g., due to a `wait` instruction), and the `old_pc_hw` value is `0`, the next `pc_hw` value may wrap **backward** by 4 bytes (e.g., from `0x0` to `0x3fffc`), due to hardware behavior. This inverse wrap was not correctly handled in the code, and `pc_offset` remained unchanged.

As a result, the program counter (`pc`) appeared to **advance** incorrectly by `0x40000`, causing `pc > mem_offset`, and ultimately triggering a **memory buffer underrun**.

### Fix

Added the following check in the PC tracking logic to detect and correct inverse wrap-around:

```c
if (pc_hw > old_pc_hw + MARGA_MEM_SIZE - 16) {
    // PC has jumped backward due to a wrap from waiting/pausing 
    debug_printf("PC Inversely wrapped: Loop %u | Mem: 0x%zx | RxReads: %u | Exec: %u | PC_HW: 0x%zx | OLD_PC_HW: 0x%zx\n",
        execution_loops, mem_offset, rx_reads_per_loop, exec, pc_hw, old_pc_hw);
    pc_offset -= MARGA_MEM_SIZE;
}
